### PR TITLE
adds stdio pipe to spawn

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -105,7 +105,7 @@ export class ExtensionFolderLocked extends Exception {
 function cmdlineToArray(text: string, result: Array<string> = [], matcher = /[^\s"]+|"([^"]*)"/gi, count = 0): Array<string> {
   text = text.replace(/\\"/g, "\ufffe");
   const match = matcher.exec(text);
-  return match ? cmdlineToArray(text, result, matcher, result.push(match[1] ? match[1].replace(/\ufffe/g, '\\"', ) : match[0].replace(/\ufffe/g, '\\"', ))) : result;
+  return match ? cmdlineToArray(text, result, matcher, result.push(match[1] ? match[1].replace(/\ufffe/g, '\\"') : match[0].replace(/\ufffe/g, '\\"'))) : result;
 }
 
 function getPathVariableName() {
@@ -611,13 +611,13 @@ export class ExtensionManager {
         process.env[PathVar] = `${path.dirname(fullCommandPath)}${path.delimiter}${env[PathVar]}`;
 
         // call spawn and return
-        return spawn(path.basename(fullCommandPath), command.slice(1), { env: env, cwd: extension.modulePath });
+        return spawn(path.basename(fullCommandPath), command.slice(1), { env: env, cwd: extension.modulePath, stdio: ["pipe", "pipe", "pipe"] });
       } finally {
         // regardless, restore the original path on the way out!
         process.env[PathVar] = originalPath;
       }
     }
 
-    return spawn(fullCommandPath, command.slice(1), { env: env, cwd: extension.modulePath });
+    return spawn(fullCommandPath, command.slice(1), { env: env, cwd: extension.modulePath, stdio: ["pipe", "pipe", "pipe"] });
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "yarn": "^1.3.2",
     "@types/npm": "^2.0.28",
     "mocha-typescript": "1.1.17",
-    "@types/node": "10.9.4",
+    "@types/node": "^10.0.0",
     "mocha": "^5.0.0",
     "typescript": "^3.0.0"
   },


### PR DESCRIPTION
In some edge cases (happing in my case on circleci) spawn returns a child process without any stdout or stdin. 
These circumstances let the code in autorest-core fail (https://github.com/Azure/autorest/blob/06de16e52c241e87e3447ee7a265a9b06886ef57/src/autorest-core/lib/pipeline/plugin-endpoint.ts#L82).

Nodejs documentation to stdio: https://nodejs.org/api/child_process.html#child_process_options_stdio

Error message:
![image](https://user-images.githubusercontent.com/4057473/64869319-72473b80-d641-11e9-99fa-5361e3c60c33.png)
